### PR TITLE
feat: add re-usable, single, workflow for running CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,132 @@
+name: CI
+on:
+  workflow_call: {}
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      go-versions: ${{ steps.versions.outputs.matrix }}
+    steps:
+      - id: versions
+        run: |
+          # versions of Go that this module can still be built with (and therefore are "supported" by this project) and actively supported versions of Go
+          echo 'matrix=["1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "stable", "oldstable"]' >> $GITHUB_OUTPUT
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
+      matrix:
+        version: ${{ fromJSON(needs.setup.outputs.go-versions) }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        with:
+          go-version: ${{ matrix.version }}
+
+      - name: Test
+        run: make test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.setup.outputs.go-versions) }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        with:
+          go-version: ${{ matrix.version }}
+
+      - name: Run `make lint-ci`
+        run: make lint-ci
+
+  tidy:
+    name: Go mod tidy
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.setup.outputs.go-versions) }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        with:
+          go-version: ${{ matrix.version }}
+
+      - name: Install `tidied`
+        run: go install gitlab.com/jamietanna/tidied@latest
+
+      - name: Check for no untracked files
+        run: tidied -verbose
+
+  generate:
+    name: Generated files
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.setup.outputs.go-versions) }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        with:
+          go-version: ${{ matrix.version }}
+
+      - name: Run `make generate`
+        run: make generate
+
+      - name: Check for no untracked files
+        run: git status && git diff-index --quiet HEAD --
+
+  check:
+    name: CI
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    - lint
+    - tidy
+    - generate
+    if: always()
+    steps:
+      - name: Check all jobs status
+        run: |
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "Build job failed or was cancelled"
+            exit 1
+          fi
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "Lint job failed or was cancelled"
+            exit 1
+          fi
+          if [ "${{ needs.tidy.result }}" != "success" ]; then
+            echo "Tidy job failed or was cancelled"
+            exit 1
+          fi
+          if [ "${{ needs.generate.result }}" != "success" ]; then
+            echo "Generate job failed or was cancelled"
+            exit 1
+          fi
+          echo "All CI jobs passed"


### PR DESCRIPTION
As noted in #1, we should have a re-usable set of GitHub Actions
configuration, at least for our middlewares which have the same CI setup
in each repo, and slightly differ from `oapi-codegen` itself.

This also simplifies things with a single CI job that can now be called
from other workflows, and ensures a minimum version of Go used, through
to also including `stable` and `oldstable`, so we stay in sync with
upstream changes as they're released.

With help from Claude to simplify the previous multiple jobs, and
provide a single resulting stage that can be used for a required status
check.

Closes #1.

Co-authored-by: Claude Sonnet 4.5 <github-copilot@jamietanna.co.uk>
