### PR TITLE
chore: Update CI Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - id: versions
         run: |
           # versions of Go that this module can still be built with (and therefore are "supported" by this project) and actively supported versions of Go
-          all_versions='["1.22", "1.23", "1.24", "1.25", "stable", "oldstable"]'
+          all_versions='["1.24", "1.25", "1.26"]'
           excluding='${{ inputs.excluding_versions }}'
 
           # Filter out excluded versions using jq


### PR DESCRIPTION
With Go 1.26 releasing, we're advancing our supported Go versions to [1.24, 1.25, and 1.26]. I removed "stable" and "oldstable" since they overlap with "1.26" and "1.25", respectively, and it doesn't make sense to double up on the CI. New versions of Go happen so seldom, and we change this requirement so infrequently, that I think it's ok to use fixed versions.