### PR TITLE
fix: run `tidy-ci` instead of `tidied`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,8 @@ jobs:
       - name: Install `tidied`
         run: go install gitlab.com/jamietanna/tidied@latest
 
-      - name: Check for no untracked files
-        run: tidied -verbose
+      - name: Run `make tidy-ci`
+        run: make tidy-ci
 
   generate:
     name: Generated files


### PR DESCRIPTION
As noted in https://github.com/oapi-codegen/oapi-codegen/pull/2372,
otherwise this leads to cases where we're not correctly `go mod tidy`ing
across the project.

As all our projects have a `tidy-ci`, we can use that task.