### PR TITLE
fix!: remove tidied

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,6 @@ jobs:
         with:
           go-version: ${{ matrix.version }}
 
-      - name: Install `tidied`
-        run: go install gitlab.com/jamietanna/tidied@latest
-
       - name: Run `make tidy-ci`
         run: make tidy-ci
 


### PR DESCRIPTION
`tidied` replaced with `go mod tidy -diff`.

Follows https://github.com/oapi-codegen/oapi-codegen/pull/2482