### PR TITLE
fix(generate): show full diff when `make generate` fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           GOTOOLCHAIN: local
 
       - name: Check for no untracked files
-        run: git status && git diff-index --quiet HEAD --
+        run: git status && git diff --patch --exit-code HEAD --
 
   check:
     name: CI


### PR DESCRIPTION
So it's easier to debug, we can show a full diff, while making sure to
return an exit code as we expect.
